### PR TITLE
Using spl_autoload_register method to autoload classes. I was using t…

### DIFF
--- a/cascade_ws_ns/class_files.php
+++ b/cascade_ws_ns/class_files.php
@@ -7,7 +7,9 @@ use cascade_ws_asset     as asset;
 use cascade_ws_exception as exception;
 */
 
-function __autoload( $classname )
+spl_autoload_register('cascade__autoload');
+
+function cascade__autoload( $classname )
 {
 	$array =
 		utility\StringUtility::getExplodedStringArray( "\\", $classname );
@@ -32,4 +34,4 @@ function __autoload( $classname )
     else if( file_exists( $root_path . $utility_class_folder . $file ) )
         require_once( $root_path . $utility_class_folder . $file );
 }
-?>
+


### PR DESCRIPTION
…he Silex framework that has it's own registered autoloader, and since __autoload does not isolate file requirements by namespace, this was breaking either the Cascade WSDL lib or the framework.
